### PR TITLE
Add resynchornization feature + background sync changes

### DIFF
--- a/app/src/main/java/sugar/free/sightremote/activities/SightActivity.java
+++ b/app/src/main/java/sugar/free/sightremote/activities/SightActivity.java
@@ -2,6 +2,7 @@ package sugar.free.sightremote.activities;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
@@ -32,6 +33,7 @@ import sugar.free.sightremote.database.DatabaseHelper;
 public abstract class SightActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener {
 
     private DatabaseHelper databaseHelper;
+    private SharedPreferences sharedPreferences;
 
     private DrawerLayout drawerLayout;
     private NavigationView navigationView;
@@ -287,5 +289,11 @@ public abstract class SightActivity extends AppCompatActivity implements Navigat
             OpenHelperManager.releaseHelper();
             databaseHelper = null;
         }
+    }
+
+    protected SharedPreferences getPreferences() {
+        if (sharedPreferences == null)
+            sharedPreferences = getSharedPreferences("sugar.free.sightremote.services.SIGHTREMOTE", MODE_PRIVATE);
+        return sharedPreferences;
     }
 }

--- a/app/src/main/java/sugar/free/sightremote/activities/StatusActivity.java
+++ b/app/src/main/java/sugar/free/sightremote/activities/StatusActivity.java
@@ -81,6 +81,7 @@ public class StatusActivity extends SightActivity implements TaskRunner.ResultCa
     private TextView noActiveProcesses;
     private MenuItem startPump;
     private MenuItem stopPump;
+    private MenuItem backgroundSync;
     private Button cancelTBR;
     private Button cancelBolus1;
     private Button cancelBolus2;
@@ -316,6 +317,7 @@ public class StatusActivity extends SightActivity implements TaskRunner.ResultCa
         inflater.inflate(R.menu.status_menu, menu);
         startPump = menu.findItem(R.id.status_nav_start);
         stopPump = menu.findItem(R.id.status_nav_stop);
+        backgroundSync = menu.findItem(R.id.status_nav_background_sync);
         if (statusResult != null) {
             if (statusResult.getPumpStatusMessage().getPumpStatus() == PumpStatus.STARTED) startPump.setVisible(false);
             else stopPump.setVisible(false);
@@ -323,6 +325,7 @@ public class StatusActivity extends SightActivity implements TaskRunner.ResultCa
             startPump.setVisible(false);
             stopPump.setVisible(false);
         }
+        updateBackgroundSyncMenu();
         return true;
     }
     @Override
@@ -463,4 +466,18 @@ public class StatusActivity extends SightActivity implements TaskRunner.ResultCa
             }
         }
     };
+
+    public void backgroundSyncCheck(MenuItem item) {
+        getPreferences().edit().putBoolean("background_sync_enabled", !isBackGroundSyncEnabled()).apply();
+        updateBackgroundSyncMenu();
+        sendBroadcast(new Intent(HistoryBroadcast.ACTION_START_SYNC));
+    }
+
+    private boolean isBackGroundSyncEnabled() {
+        return getPreferences().getBoolean("background_sync_enabled",false);
+    }
+
+    private void updateBackgroundSyncMenu() {
+        backgroundSync.setChecked(isBackGroundSyncEnabled());
+    }
 }

--- a/app/src/main/java/sugar/free/sightremote/services/HistoryResync.java
+++ b/app/src/main/java/sugar/free/sightremote/services/HistoryResync.java
@@ -1,0 +1,65 @@
+package sugar.free.sightremote.services;
+
+import android.content.Context;
+
+import java.sql.SQLException;
+import java.util.Date;
+import java.util.List;
+
+import sugar.free.sightremote.database.BolusDelivered;
+import sugar.free.sightremote.database.DatabaseHelper;
+import sugar.free.sightremote.database.EndOfTBR;
+
+/**
+ * Created by jamorham on 28/01/2018.
+ *
+ * Send the last 24 hours records from our database store
+ */
+
+class HistoryResync {
+
+    private static final String TAG = "HistoryResync";
+    private DatabaseHelper databaseHelper;
+    private Context context;
+
+    HistoryResync(Context context, DatabaseHelper databaseHelper) {
+        this.databaseHelper = databaseHelper;
+        this.context = context;
+    }
+
+    void doResync() {
+        resyncFromDatabase();
+    }
+
+    private void resyncFromDatabase() {
+
+        final Date yesterday = new Date(System.currentTimeMillis() - 86400000);
+
+        try {
+            final List<EndOfTBR> records = databaseHelper.getEndOfTBRDao().queryBuilder()
+                    .orderBy("dateTime", true)
+                    .where().ge("dateTime", yesterday).query();
+
+            android.util.Log.d(TAG, "Resending TBR list " + records.size());
+            for (EndOfTBR endOfTBR : records) {
+                HistorySendIntent.sendEndOfTBR(context, endOfTBR);
+            }
+        } catch (SQLException e) {
+            android.util.Log.e(TAG, "SQL ERROR: " + e);
+        }
+
+        try {
+            final List<BolusDelivered> records = databaseHelper.getBolusDeliveredDao().queryBuilder()
+                    .orderBy("dateTime", true)
+                    .where().ge("dateTime", yesterday).query();
+
+            android.util.Log.d("HistoryResync", "Resending Bolus list " + records.size());
+            for (BolusDelivered bolusDelivered : records) {
+                HistorySendIntent.sendBolusDelivered(context, bolusDelivered);
+            }
+        } catch (SQLException e) {
+            android.util.Log.e(TAG, "SQL ERROR: " + e);
+        }
+
+    }
+}

--- a/app/src/main/java/sugar/free/sightremote/services/HistorySendIntent.java
+++ b/app/src/main/java/sugar/free/sightremote/services/HistorySendIntent.java
@@ -1,0 +1,92 @@
+package sugar.free.sightremote.services;
+
+import android.content.Context;
+import android.content.Intent;
+
+import sugar.free.sightparser.handling.HistoryBroadcast;
+import sugar.free.sightremote.database.BolusDelivered;
+import sugar.free.sightremote.database.BolusProgrammed;
+import sugar.free.sightremote.database.CannulaFilled;
+import sugar.free.sightremote.database.EndOfTBR;
+import sugar.free.sightremote.database.PumpStatusChanged;
+import sugar.free.sightremote.database.TimeChanged;
+
+/**
+ * Created by jamorham on 28/01/2018.
+ */
+
+class HistorySendIntent {
+
+    static void sendEndOfTBR(Context context, EndOfTBR endOfTBR) {
+        Intent intent = new Intent();
+        intent.setAction(HistoryBroadcast.ACTION_END_OF_TBR);
+        intent.putExtra(HistoryBroadcast.EXTRA_DURATION, endOfTBR.getDuration());
+        intent.putExtra(HistoryBroadcast.EXTRA_TBR_AMOUNT, endOfTBR.getAmount());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_NUMBER, endOfTBR.getEventNumber());
+        intent.putExtra(HistoryBroadcast.EXTRA_PUMP_SERIAL_NUMBER, endOfTBR.getPump());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_TIME, endOfTBR.getDateTime());
+        intent.putExtra(HistoryBroadcast.EXTRA_START_TIME, endOfTBR.getStartTime());
+        context.sendBroadcast(intent);
+    }
+
+    static void sendBolusDelivered(Context context, BolusDelivered bolusDelivered) {
+        Intent intent = new Intent();
+        intent.setAction(HistoryBroadcast.ACTION_BOLUS_DELIVERED);
+        intent.putExtra(HistoryBroadcast.EXTRA_BOLUS_ID, bolusDelivered.getBolusId());
+        intent.putExtra(HistoryBroadcast.EXTRA_BOLUS_TYPE, bolusDelivered.getBolusType().toString());
+        intent.putExtra(HistoryBroadcast.EXTRA_DURATION, bolusDelivered.getDuration());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_NUMBER, bolusDelivered.getEventNumber());
+        intent.putExtra(HistoryBroadcast.EXTRA_EXTENDED_AMOUNT, bolusDelivered.getExtendedAmount());
+        intent.putExtra(HistoryBroadcast.EXTRA_IMMEDIATE_AMOUNT, bolusDelivered.getImmediateAmount());
+        intent.putExtra(HistoryBroadcast.EXTRA_PUMP_SERIAL_NUMBER, bolusDelivered.getPump());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_TIME, bolusDelivered.getDateTime());
+        intent.putExtra(HistoryBroadcast.EXTRA_START_TIME, bolusDelivered.getStartTime());
+        context.sendBroadcast(intent);
+    }
+
+    static void sendBolusProgrammed(Context context, BolusProgrammed bolusProgrammed) {
+        Intent intent = new Intent();
+        intent.setAction(HistoryBroadcast.ACTION_BOLUS_PROGRAMMED);
+        intent.putExtra(HistoryBroadcast.EXTRA_BOLUS_ID, bolusProgrammed.getBolusId());
+        intent.putExtra(HistoryBroadcast.EXTRA_BOLUS_TYPE, bolusProgrammed.getBolusType().toString());
+        intent.putExtra(HistoryBroadcast.EXTRA_DURATION, bolusProgrammed.getDuration());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_NUMBER, bolusProgrammed.getEventNumber());
+        intent.putExtra(HistoryBroadcast.EXTRA_EXTENDED_AMOUNT, bolusProgrammed.getExtendedAmount());
+        intent.putExtra(HistoryBroadcast.EXTRA_IMMEDIATE_AMOUNT, bolusProgrammed.getImmediateAmount());
+        intent.putExtra(HistoryBroadcast.EXTRA_PUMP_SERIAL_NUMBER, bolusProgrammed.getPump());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_TIME, bolusProgrammed.getDateTime());
+        context.sendBroadcast(intent);
+    }
+
+    static void sendPumpStatusChanged(Context context, PumpStatusChanged pumpStatusChanged) {
+        Intent intent = new Intent();
+        intent.setAction(HistoryBroadcast.ACTION_PUMP_STATUS_CHANGED);
+        intent.putExtra(HistoryBroadcast.EXTRA_OLD_STATUS, pumpStatusChanged.getOldValue().toString());
+        intent.putExtra(HistoryBroadcast.EXTRA_NEW_STATUS, pumpStatusChanged.getNewValue().toString());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_NUMBER, pumpStatusChanged.getEventNumber());
+        intent.putExtra(HistoryBroadcast.EXTRA_PUMP_SERIAL_NUMBER, pumpStatusChanged.getPump());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_TIME, pumpStatusChanged.getDateTime());
+        context.sendBroadcast(intent);
+    }
+
+    static void sendTimeChanged(Context context, TimeChanged timeChanged) {
+        Intent intent = new Intent();
+        intent.setAction(HistoryBroadcast.ACTION_TIME_CHANGED);
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_TIME, timeChanged.getDateTime());
+        intent.putExtra(HistoryBroadcast.EXTRA_TIME_BEFORE, timeChanged.getTimeBefore());
+        intent.putExtra(HistoryBroadcast.EXTRA_PUMP_SERIAL_NUMBER, timeChanged.getPump());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_NUMBER, timeChanged.getEventNumber());
+        context.sendBroadcast(intent);
+    }
+
+    static void sendCannulaFilled(Context context, CannulaFilled cannulaFilled) {
+        Intent intent = new Intent();
+        intent.setAction(HistoryBroadcast.ACTION_PUMP_STATUS_CHANGED);
+        intent.putExtra(HistoryBroadcast.EXTRA_FILL_AMOUNT, cannulaFilled.getAmount());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_NUMBER, cannulaFilled.getEventNumber());
+        intent.putExtra(HistoryBroadcast.EXTRA_PUMP_SERIAL_NUMBER, cannulaFilled.getPump());
+        intent.putExtra(HistoryBroadcast.EXTRA_EVENT_TIME, cannulaFilled.getDateTime());
+        context.sendBroadcast(intent);
+    }
+
+}

--- a/app/src/main/res/menu/status_menu.xml
+++ b/app/src/main/res/menu/status_menu.xml
@@ -9,6 +9,11 @@
         android:title="@string/start_pump"
         android:icon="@drawable/ic_start"
         app:showAsAction="ifRoom" />
+    <item android:id="@+id/status_nav_background_sync"
+        android:checkable="true"
+        android:onClick="backgroundSyncCheck"
+        android:title="@string/background_sync"
+        app:showAsAction="never" />
     <item android:id="@+id/status_nav_delete_pairing"
         android:title="@string/delete_pairing"
         app:showAsAction="never" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,4 +89,5 @@
     <string name="latest_bolus_standard">%1$s: %2$s</string>
     <string name="latest_bolus_extended">%1$s: %2$s für %3$02d:%4$02d</string>
     <string name="latest_bolus_multiwave">%1$s: %2$s, %3$s für %4$02d:%5$02d</string>
+    <string name="background_sync">Hintergrundsynchronisation</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,4 +88,5 @@
     <string name="latest_bolus_standard">%1$s: %2$s</string>
     <string name="latest_bolus_extended">%1$s: %2$s for %3$02d:%4$02d</string>
     <string name="latest_bolus_multiwave">%1$s: %2$s, %3$s for %4$02d:%5$02d</string>
+    <string name="background_sync">Background Sync</string>
 </resources>

--- a/sightparser/src/main/java/sugar/free/sightparser/handling/HistoryBroadcast.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/handling/HistoryBroadcast.java
@@ -4,6 +4,7 @@ public class HistoryBroadcast {
 
     //Sent to service
     public static final String ACTION_START_SYNC = "sugar.free.sightremote.services.HistorySyncService.START_SYNC";
+    public static final String ACTION_START_RESYNC = "sugar.free.sightremote.services.HistorySyncService.START_RESYNC";
 
     //Sent from service
     public static final String ACTION_BOLUS_DELIVERED = "sugar.free.sightremote.services.HistorySyncService.BOLUS_DELIVERED";


### PR DESCRIPTION
Adds a RESYNC intent action which causes the service to push the last 24 hours database records through the intents. This is useful to sync data to another app which has already been loaded within SightRemote but is missing from the other app.

Changes the background sync feature to be controlled by a menu item in the activity. Switching this on results in the original behavior.  I am concerned that the existing always-on repeating alarm driving the service is going to cause problems so have made this optional. When using with AAPS that will trigger the history sync itself.

To avoid code duplication I moved the intent sender to their own class.