### PR TITLE
Add activation dialog chain

### DIFF
--- a/app/src/main/java/sugar/free/sightremote/activities/StatusActivity.java
+++ b/app/src/main/java/sugar/free/sightremote/activities/StatusActivity.java
@@ -43,6 +43,7 @@ import sugar.free.sightparser.pipeline.Status;
 import sugar.free.sightremote.R;
 import sugar.free.sightparser.handling.taskrunners.StatusTaskRunner;
 import sugar.free.sightremote.database.BolusDelivered;
+import sugar.free.sightremote.utils.ActivationWarningDialogChain;
 import sugar.free.sightremote.utils.UnitFormatter;
 
 public class StatusActivity extends SightActivity implements TaskRunner.ResultCallback, View.OnClickListener {
@@ -380,14 +381,7 @@ public class StatusActivity extends SightActivity implements TaskRunner.ResultCa
                     .setNegativeButton(R.string.cancel, null)
                     .show();
         } else if (item.getItemId() == R.id.status_nav_enter_password) {
-            final EditText input = new EditText(this);
-            input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-            new AlertDialog.Builder(this)
-                    .setView(input)
-                    .setTitle(R.string.enter_password)
-                    .setPositiveButton(R.string.okay, (dialog, which) -> getServiceConnector().setPassword(input.getText().toString()))
-                    .setNegativeButton(R.string.cancel, null)
-                    .show();
+            new ActivationWarningDialogChain(this, getServiceConnector()).doActivationWarning();
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/sugar/free/sightremote/utils/ActivationWarningDialogChain.java
+++ b/app/src/main/java/sugar/free/sightremote/utils/ActivationWarningDialogChain.java
@@ -1,0 +1,106 @@
+package sugar.free.sightremote.utils;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.text.InputType;
+import android.widget.EditText;
+
+import sugar.free.sightparser.handling.SightServiceConnector;
+import sugar.free.sightremote.R;
+
+import static android.content.Context.MODE_PRIVATE;
+
+/**
+ * Created by jamorham on 28/01/2018.
+ */
+
+public class ActivationWarningDialogChain {
+
+    private final SightServiceConnector sightServiceConnector;
+    private final Context context;
+    private SharedPreferences sharedServicePerferences;
+
+    public ActivationWarningDialogChain(Context context, SightServiceConnector sightServiceConnector) {
+        this.context = context;
+        this.sightServiceConnector = sightServiceConnector;
+    }
+
+    public void doActivationWarning() {
+
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(context.getString(R.string.safety_warning));
+        builder.setMessage(R.string.safety_warning_text1);
+        builder.setNeutralButton(context.getString(R.string.cancel), (dialog, which) -> dialog.dismiss());
+
+        builder.setPositiveButton(context.getString(R.string.connected_to_a_person), (dialog, which) -> {
+            dialog.dismiss();
+            doPersonWarningDialog();
+        });
+
+        builder.setNegativeButton(context.getString(R.string.never_connected_to_a_person), (dialog, which) -> {
+            dialog.dismiss();
+            areYouSureDialog();
+        });
+
+        final AlertDialog alert = builder.create();
+        alert.show();
+    }
+
+    private void doPersonWarningDialog() {
+
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(context.getString(R.string.safety_warning));
+        builder.setMessage(context.getString(R.string.are_you_a_qualified_medical_professional));
+        builder.setNeutralButton(context.getString(R.string.cancel), (dialog, which) -> dialog.dismiss());
+
+        builder.setPositiveButton(context.getString(R.string.yes_i_am_a_medical_professional), (dialog, which) -> {
+            dialog.dismiss();
+            areYouSureDialog();
+        });
+
+        builder.setNegativeButton(context.getString(R.string.no), (dialog, which) -> dialog.dismiss());
+
+        final AlertDialog alert = builder.create();
+        alert.show();
+    }
+
+    private void areYouSureDialog() {
+
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(context.getString(R.string.safety_warning));
+        builder.setMessage(context.getString(R.string.are_you_absolutely_sure_activate));
+        builder.setNeutralButton(context.getString(R.string.cancel), (dialog, which) -> dialog.dismiss());
+
+        builder.setPositiveButton(context.getString(R.string.yes), (dialog, which) -> {
+            dialog.dismiss();
+            requestPassword();
+        });
+
+        builder.setNegativeButton(context.getString(R.string.no), (dialog, which) -> dialog.dismiss());
+
+        final AlertDialog alert = builder.create();
+        alert.show();
+    }
+
+    private void requestPassword() {
+        final EditText input = new EditText(context);
+        input.setInputType(InputType.TYPE_CLASS_TEXT);
+        input.setText(getServicePreferences().getString("PASSWORD", ""));
+
+        new AlertDialog.Builder(context)
+                .setView(input)
+                .setTitle(R.string.enter_password)
+                .setMessage(context.getString(R.string.please_enter_activation_password))
+                .setPositiveButton(R.string.okay, (dialog, which) -> sightServiceConnector.setPassword(input.getText().toString().trim()))
+                .setNegativeButton(R.string.cancel, null)
+                .show();
+    }
+
+    private SharedPreferences getServicePreferences() {
+        if (sharedServicePerferences == null)
+            sharedServicePerferences = context.getSharedPreferences("sugar.free.sightremote.services.SIGHTSERVICE", MODE_PRIVATE);
+        return sharedServicePerferences;
+    }
+
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,6 +90,15 @@
     <string name="latest_bolus_extended">%1$s: %2$s für %3$02d:%4$02d</string>
     <string name="latest_bolus_multiwave">%1$s: %2$s, %3$s für %4$02d:%5$02d</string>
     <string name="background_sync">Hintergrundsynchronisation</string>
+    <string name="please_enter_activation_password">Please enter the Insulin service activation password:</string>
+    <string name="no">Nein</string>
+    <string name="safety_warning">Safety Warning!</string>
+    <string name="safety_warning_text1">Activating the Insulin service allows this app to deliver or adjust insulin delivery on the pump!  If the pump is ever going to be connected to a person then this activation must only be performed by a medical professional responsible for their care.</string>
+    <string name="connected_to_a_person">Connected to a person</string>
+    <string name="never_connected_to_a_person">Never connected to a person</string>
+    <string name="are_you_a_qualified_medical_professional">Are you a qualified medicial professional responsible for the care of the person who\'s insulin pump this application is paired with?</string>
+    <string name="yes_i_am_a_medical_professional">Yes, I am a qualified medical professional responsible for their care</string>
+    <string name="are_you_absolutely_sure_activate">Are you absolutely sure you wish to activate the Insulin service and that you fully understand what this does?</string>
     <string name="br_unit_formatter">%1$sU/h</string>
     <string name="br_block_formatter">%1$s - %2$s</string>
     <string name="br_start_time">Anfang:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,15 @@
     <string name="latest_bolus_extended">%1$s: %2$s for %3$02d:%4$02d</string>
     <string name="latest_bolus_multiwave">%1$s: %2$s, %3$s for %4$02d:%5$02d</string>
     <string name="background_sync">Background Sync</string>
+    <string name="please_enter_activation_password">Please enter the Insulin service activation password:</string>
+    <string name="no">No</string>
+    <string name="safety_warning">Safety Warning!</string>
+    <string name="safety_warning_text1">Activating the Insulin service allows this app to deliver or adjust insulin delivery on the pump!  If the pump is ever going to be connected to a person then this activation must only be performed by a medical professional responsible for their care.</string>
+    <string name="connected_to_a_person">Connected to a person</string>
+    <string name="never_connected_to_a_person">Never connected to a person</string>
+    <string name="are_you_a_qualified_medical_professional">Are you a qualified medicial professional responsible for the care of the person who\'s insulin pump this application is paired with?</string>
+    <string name="yes_i_am_a_medical_professional">Yes, I am a qualified medical professional responsible for their care</string>
+    <string name="are_you_absolutely_sure_activate">Are you absolutely sure you wish to activate the Insulin service and that you fully understand what this does?</string>
     <string name="br_block_formatter">%1$s - %2$s</string>
     <string name="br_start_time">Start time:</string>
     <string name="br_end_time">End time:</string>


### PR DESCRIPTION
This puts a chain of dialogs before the password entry feature to provide additional warnings to the user before proceeding.

Please note the German strings have not been translated yet but I pasted the English text in there to avoid compilation errors.