### PR TITLE
Add service authorization pop-up feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
             android:label="@string/tbr_data" />
         <activity
             android:name=".activities.EditBRProfileActivity" />
+        <activity android:name=".activities.AuthorizeActivity" />
 
         <service
             android:name=".services.HistorySyncService"

--- a/app/src/main/java/sugar/free/sightremote/activities/AuthorizeActivity.java
+++ b/app/src/main/java/sugar/free/sightremote/activities/AuthorizeActivity.java
@@ -1,0 +1,59 @@
+package sugar.free.sightremote.activities;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import sugar.free.sightremote.R;
+
+/**
+ * Created by jamorham on 30/01/2018.
+ */
+
+public class AuthorizeActivity extends SightActivity {
+
+    private static final String AUTHORIZE_POLL_EXTRA = "authorize_poll";
+    private String packageName;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_authorize);
+
+        final Bundle bundle = getIntent().getExtras();
+        if (bundle != null) {
+            packageName = bundle.getString(AUTHORIZE_POLL_EXTRA, "");
+            if (packageName.length() > 0) {
+                ((TextView) findViewById(R.id.packageText)).setText(packageName);
+                try {
+                    Drawable icon = getPackageManager().getApplicationIcon(packageName);
+                    ((ImageView) findViewById(R.id.packageIcon)).setImageDrawable(icon);
+                    ApplicationInfo applicationInfo = getPackageManager().getApplicationInfo(packageName, 0);
+                    CharSequence applicationLabel = getPackageManager().getApplicationLabel(applicationInfo);
+                    ((TextView) findViewById(R.id.packageName)).setText(applicationLabel);
+                } catch (PackageManager.NameNotFoundException e) {
+                    // hmmm
+                }
+            } else {
+                finish();
+            }
+        }
+    }
+
+    public void onDenyClick(View v) {
+        getServiceConnector().setAuthorized(packageName, false);
+        finish();
+    }
+
+    public void onAllowClick(View v) {
+        getServiceConnector().setAuthorized(packageName, true);
+        finish();
+    }
+
+}
+

--- a/app/src/main/java/sugar/free/sightremote/activities/LauncherActivity.java
+++ b/app/src/main/java/sugar/free/sightremote/activities/LauncherActivity.java
@@ -7,12 +7,19 @@ import android.support.v7.app.AppCompatActivity;
 
 public class LauncherActivity extends AppCompatActivity {
 
+    private static final String AUTHORIZE_POLL_EXTRA = "authorize_poll";
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (getSharedPreferences("sugar.free.sightremote.services.SIGHTSERVICE", MODE_PRIVATE).contains("DEVICEMAC"))
-            startActivity(new Intent(this, StatusActivity.class));
-        else startActivity(new Intent(this, SetupActivity.class));
+        final Bundle bundle = getIntent().getExtras();
+        if ((bundle != null) && (!bundle.getString(AUTHORIZE_POLL_EXTRA, "").equals(""))) {
+            startActivity(new Intent(this, AuthorizeActivity.class).putExtra(AUTHORIZE_POLL_EXTRA, bundle.getString(AUTHORIZE_POLL_EXTRA)));
+        } else {
+            if (getSharedPreferences("sugar.free.sightremote.services.SIGHTSERVICE", MODE_PRIVATE).contains("DEVICEMAC"))
+                startActivity(new Intent(this, StatusActivity.class));
+            else startActivity(new Intent(this, SetupActivity.class));
+        }
         finish();
     }
 }

--- a/app/src/main/res/layout/activity_authorize.xml
+++ b/app/src/main/res/layout/activity_authorize.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/packageText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="14dp"
+        android:text="packagename.package.package"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
+        android:textColor="@android:color/primary_text_light"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/titleView" />
+
+    <TextView
+        android:id="@+id/titleView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="28dp"
+        android:text="@string/another_application_is_requesting_access_to_the_pump"
+        android:textAlignment="center"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
+        android:textColor="@color/colorPrimaryDark"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/allowbutton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:onClick="onAllowClick"
+        android:text="@string/allow"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/denybutton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/packageText" />
+
+    <Button
+        android:id="@+id/denybutton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginTop="8dp"
+        android:onClick="onDenyClick"
+        android:text="@string/deny"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/allowbutton"
+        app:layout_constraintTop_toBottomOf="@+id/packageText" />
+
+    <ImageView
+        android:id="@+id/packageIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="18dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/packageText" />
+
+    <TextView
+        android:id="@+id/packageName"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:text="Package Name"
+        app:layout_constraintBottom_toTopOf="@+id/allowbutton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/packageIcon" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -112,4 +112,7 @@
     <string name="done">Fertig</string>
     <string name="edit_name">Name bearbeiten</string>
     <string name="leave_empty_for_default_value">Leer lassen für Standardwert</string>
+    <string name="deny">Ablehnen</string>
+    <string name="allow">Erlauben</string>
+    <string name="another_application_is_requesting_access_to_the_pump">Eine andere Anwendung möchte auf deine Pumpe zugreifen!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,4 +111,7 @@
     <string name="done">Done</string>
     <string name="edit_name">Edit name</string>
     <string name="leave_empty_for_default_value">Leave empty for default value</string>
+    <string name="deny">Deny</string>
+    <string name="allow">Allow</string>
+    <string name="another_application_is_requesting_access_to_the_pump">Another application is requesting access to the pump!</string>
 </resources>

--- a/sightparser/src/main/aidl/sugar/free/sightparser/handling/ISightService.aidl
+++ b/sightparser/src/main/aidl/sugar/free/sightparser/handling/ISightService.aidl
@@ -5,6 +5,7 @@ import sugar.free.sightparser.handling.IStatusCallback;
 
 interface ISightService {
 
+    String getRemoteVersion();
     void pair(String mac, IBinder binder);
     boolean isUseable();
     String getStatus();
@@ -14,5 +15,6 @@ interface ISightService {
     void connect(IBinder binder);
     void disconnect(IBinder binder);
     void setPassword(String password);
+    void setAuthorized(String packageName, boolean allowed);
     void reset();
 }

--- a/sightparser/src/main/java/sugar/free/sightparser/error/NotAuthorizedError.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/error/NotAuthorizedError.java
@@ -1,0 +1,4 @@
+package sugar.free.sightparser.error;
+
+public class NotAuthorizedError extends SightError {
+}

--- a/sightparser/src/main/java/sugar/free/sightparser/handling/SightServiceConnector.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/handling/SightServiceConnector.java
@@ -58,6 +58,8 @@ public class SightServiceConnector {
                     }
                 });
             } catch (RemoteException e) {
+            } catch (NullPointerException e) {
+                android.util.Log.e("SightServiceConnector", "Null pointer exception, probably incompatible application interface - upgrade them to compantible versions", e);
             }
             if (connectLatch != null) connectLatch.countDown();
             if (connectionCallback != null) connectionCallback.onServiceConnected();
@@ -188,6 +190,14 @@ public class SightServiceConnector {
     public void setPassword(String password) {
         try {
             boundService.setPassword(password);
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setAuthorized(String packageName, boolean allowed) {
+        try {
+            boundService.setAuthorized(packageName, allowed);
         } catch (RemoteException e) {
             e.printStackTrace();
         }

--- a/sightparser/src/main/java/sugar/free/sightparser/pipeline/Status.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/pipeline/Status.java
@@ -8,6 +8,8 @@ public enum Status {
     APP_BINDING,
     CONNECTING,
     CONNECTED,
-    DISCONNECTED
+    DISCONNECTED,
+    NOT_AUTHORIZED,
+    INCOMPATIBLE
 
 }


### PR DESCRIPTION
This adds the authorized activity which will pop-up an allow / deny page when an unauthorized application tries to use the service. If the user allows it then everything proceeds as normal.

Some API features are restricted to admin which is set as the `sugar.free.sightremote` package only.

It doesn't yet check for uninstalled packages or changes in uid (reinstallations or new packages) but I think it is worth integrating as it meets the current use case, eg AAPS user wishes to use it as a driver, approves it and keeps both installed forever. It is much better than the existing security model and easily can be expanded to cover more complex use cases.

The aidl interface has a new `setAuthorized(String packageName, boolean allowed)` method which is restricted to admin.

As discussed the aidl interface also adds a new version request string to marry versions of client + service and avoid mismatches.

The changes in `SightService` look bigger than they are just because each method is wrapped with a `verifyCaller()` check.

I've tested this and it appears to work well.
