### PR TITLE
Add firewalling feature enable/disable access to pump features

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,10 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+
+    }
+    dataBinding {
+        enabled = true
     }
     lintOptions {
         abortOnError false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,7 @@
             android:name=".activities.AlertActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar.NoStatusBackground" />
+        <activity android:name=".activities.FirewallActivity" />
 
         <service
             android:name=".services.HistorySyncService"

--- a/app/src/main/java/sugar/free/sightremote/activities/FirewallActivity.java
+++ b/app/src/main/java/sugar/free/sightremote/activities/FirewallActivity.java
@@ -1,0 +1,35 @@
+package sugar.free.sightremote.activities;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+import sugar.free.sightparser.handling.FirewallConstraint;
+import sugar.free.sightremote.R;
+import sugar.free.sightremote.adapters.PrefsViewImpl;
+import sugar.free.sightremote.databinding.ActivityFirewallBinding;
+
+/**
+ * Created by jamorham on 30/01/2018.
+ *
+ * Activity to manage firewall preferences
+ *
+ * Layout and wiring is in activity_firewall.xml
+ */
+
+public class FirewallActivity extends SightActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_firewall);
+
+        // to initialize defaults
+        FirewallConstraint fw = new FirewallConstraint(getApplicationContext());
+        fw = null;
+
+        final ActivityFirewallBinding binding = ActivityFirewallBinding.inflate(getLayoutInflater());
+        binding.setPrefs(new PrefsViewImpl(getApplicationContext(), "ACTIVITY_FIREWALL", getServiceConnector()));
+        setContentView(binding.getRoot());
+    }
+}
+

--- a/app/src/main/java/sugar/free/sightremote/adapters/BindingAdapterUtils.java
+++ b/app/src/main/java/sugar/free/sightremote/adapters/BindingAdapterUtils.java
@@ -1,0 +1,17 @@
+package sugar.free.sightremote.adapters;
+
+import android.databinding.BindingAdapter;
+import android.support.annotation.NonNull;
+import android.view.View;
+
+/**
+ * Created by jamorham on 11/12/2017.
+ */
+
+public class BindingAdapterUtils {
+
+    @BindingAdapter(value = {"showIfTrue"}, requireAll = true)
+    public static void setShowIfTrue(@NonNull View view, boolean isVisible) {
+        view.setVisibility(isVisible ? View.VISIBLE : View.GONE);
+    }
+}

--- a/app/src/main/java/sugar/free/sightremote/adapters/PrefsView.java
+++ b/app/src/main/java/sugar/free/sightremote/adapters/PrefsView.java
@@ -1,0 +1,16 @@
+package sugar.free.sightremote.adapters;
+
+/**
+ * Created by jamorham on 04/10/2017.
+ *
+ * Interface between preferences and view
+ */
+
+public interface PrefsView {
+
+    boolean getbool(String name);
+
+    void setbool(String name, boolean value);
+
+    void togglebool(String name);
+}

--- a/app/src/main/java/sugar/free/sightremote/adapters/PrefsViewImpl.java
+++ b/app/src/main/java/sugar/free/sightremote/adapters/PrefsViewImpl.java
@@ -1,0 +1,47 @@
+package sugar.free.sightremote.adapters;
+
+import android.content.Context;
+import android.databinding.BaseObservable;
+
+import sugar.free.sightparser.Pref;
+import sugar.free.sightparser.handling.SightServiceConnector;
+
+import static sugar.free.sightparser.Pref.CHANGE_PREFS_SPECIAL_CASE;
+import static sugar.free.sightparser.Pref.CHANGE_PREFS_SPECIAL_CASE_DELIMITER;
+
+/**
+ * Created by jamorham on 05/10/2017.
+ *
+ * Implementation of PrefsView
+ */
+
+public class PrefsViewImpl extends BaseObservable implements PrefsView {
+
+
+    private final Pref pref;
+    private final SightServiceConnector connector;
+
+    public PrefsViewImpl(Context context, String prefix, SightServiceConnector connector) {
+        this.pref = Pref.get(context, prefix);
+        this.connector = connector;
+    }
+
+    public boolean getbool(String name) {
+        return pref.getBooleanDefaultFalse(name);
+    }
+
+    public void setbool(String name, boolean value) {
+        pref.setBoolean(name, value);
+        notifyChange();
+
+        // send to the service process
+        if (connector != null) {
+            connector.setAuthorized(CHANGE_PREFS_SPECIAL_CASE + CHANGE_PREFS_SPECIAL_CASE_DELIMITER
+                    + name + CHANGE_PREFS_SPECIAL_CASE_DELIMITER + value, false);
+        }
+    }
+
+    public void togglebool(String name) {
+        setbool(name, !getbool(name));
+    }
+}

--- a/app/src/main/res/layout/activity_firewall.xml
+++ b/app/src/main/res/layout/activity_firewall.xml
@@ -1,0 +1,85 @@
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="prefs"
+            type="sugar.free.sightremote.adapters.PrefsView" />
+    </data>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:id="@+id/firewalllayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_horizontal"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/textView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="15dp"
+                    android:text="@string/which_pump_features_is_the_app_is_allowed_to_use" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="right"
+                    android:orientation="vertical">
+
+                    <Switch
+                        android:id="@+id/switch1"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_margin="10dp"
+                        android:checked="@{prefs.getbool(`firewall_allow_standard_bolus`)}"
+                        android:onClick="@{() -> prefs.togglebool(`firewall_allow_standard_bolus`)}"
+                        android:text="@{@string/allow_standard_boluses + @string/switch_spacer}"
+                        android:textAlignment="textEnd"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                    <Switch
+                        android:id="@+id/switch2"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_margin="10dp"
+                        android:checked="@{prefs.getbool(`firewall_allow_extended_bolus`)}"
+                        android:onClick="@{() -> prefs.togglebool(`firewall_allow_extended_bolus`)}"
+                        android:text="@{@string/allow_extended_boluses + @string/switch_spacer}"
+                        android:textAlignment="textEnd"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                    <Switch
+                        android:id="@+id/switch3"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_margin="10dp"
+                        android:checked="@{prefs.getbool(`firewall_allow_temporary_basal`)}"
+                        android:onClick="@{() -> prefs.togglebool(`firewall_allow_temporary_basal`)}"
+                        android:text="@{@string/allow_temporary_basals + @string/switch_spacer}"
+                        android:textAlignment="textEnd"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </android.support.constraint.ConstraintLayout>
+
+
+    </ScrollView>
+
+
+</layout>

--- a/app/src/main/res/menu/status_menu.xml
+++ b/app/src/main/res/menu/status_menu.xml
@@ -20,6 +20,9 @@
     <item android:id="@+id/status_nav_choose_alarm_tone"
         android:title="@string/choose_alarm_tone"
         app:showAsAction="never" />
+    <item android:id="@+id/status_nav_firewall"
+        android:title="@string/firewall_options"
+        app:showAsAction="never" />
     <item android:id="@+id/status_nav_enter_password"
         android:title="@string/enter_password"
         app:showAsAction="never" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -109,4 +109,10 @@
     <string name="active_basal_rate">Aktive Basalrate</string>
     <string name="latest_bolus">Letzter Bolus</string>
     <string name="setup">Einrichtung</string>
+    <string name="switch_spacer">"   "</string>
+    <string name="allow_standard_boluses">Allow Standard Boluses</string>
+    <string name="allow_extended_boluses">Allow Extended Boluses</string>
+    <string name="allow_temporary_basals">Allow Temporary Basals</string>
+    <string name="firewall_options">Firewall Options</string>
+    <string name="which_pump_features_is_the_app_is_allowed_to_use">Which pump features is the app is allowed to use?\n\nThis will also affect any connected app like AndroidAPS.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,4 +108,10 @@
     <string name="active_basal_rate">Active basal rate</string>
     <string name="latest_bolus">Latest bolus</string>
     <string name="setup">Setup</string>
+    <string name="switch_spacer">"   "</string>
+    <string name="allow_standard_boluses">Allow Standard Boluses</string>
+    <string name="allow_extended_boluses">Allow Extended Boluses</string>
+    <string name="allow_temporary_basals">Allow Temporary Basals</string>
+    <string name="firewall_options">Firewall Options</string>
+    <string name="which_pump_features_is_the_app_is_allowed_to_use">Which pump features is the app is allowed to use?\n\nThis will also affect any connected app like AndroidAPS.</string>
 </resources>

--- a/sightparser/src/main/java/sugar/free/sightparser/Pref.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/Pref.java
@@ -1,0 +1,151 @@
+package sugar.free.sightparser;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+import java.util.StringTokenizer;
+
+import static android.content.Context.MODE_PRIVATE;
+
+/**
+ * Created by jamorham on 01/01/2018.
+ *
+ * Simplified, access to default preferences store and helper functionality
+ *
+ * Easier to use in static mode with an application based context, but we don't have that here.
+ *
+ */
+
+public class Pref {
+    public static final String CHANGE_PREFS_SPECIAL_CASE = "CHANGE_PREFS";
+    public static final String CHANGE_PREFS_SPECIAL_CASE_DELIMITER = "^";
+
+    private static final String TAG = "Pref";
+    private static SharedPreferences prefs;
+    private static Pref instance;
+
+    private Pref(Context context, String prefix) {
+        reloadPrefs(context, prefix);
+    }
+
+    @NonNull
+    public static Pref get(Context context, String prefix) {
+        if (instance == null) {
+            instance = new Pref(context, prefix);
+        }
+        return instance;
+    }
+
+    public static Pref get() {
+        return instance;
+    }
+
+    public void reloadPrefs(Context context, String prefix) {
+        prefs = context.getSharedPreferences(prefix, MODE_PRIVATE);
+    }
+
+    // strings
+    public String getStringDefaultBlank(final String pref) {
+        return prefs.getString(pref, "");
+    }
+
+    public String getString(final String pref, final String def) {
+        return prefs.getString(pref, def);
+    }
+
+    public boolean setString(final String pref, final String str) {
+        prefs.edit().putString(pref, str).apply();
+        return true;
+    }
+
+    // numbers
+    public long getLong(final String pref, final long def) {
+        return prefs.getLong(pref, def);
+    }
+
+    public boolean setLong(final String pref, final long lng) {
+        prefs.edit().putLong(pref, lng).apply();
+        return true;
+    }
+
+    public int getInt(final String pref, final int def) {
+        return prefs.getInt(pref, def);
+    }
+
+    public int getStringToInt(final String pref, final int defaultValue) {
+        try {
+            return Integer.parseInt(getString(pref, Integer.toString(defaultValue)));
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    public boolean setInt(final String pref, final int num) {
+        prefs.edit().putInt(pref, num).apply();
+        return true;
+    }
+
+    // misc
+    public boolean removeItem(final String pref) {
+        prefs.edit().remove(pref).apply();
+        return true;
+    }
+
+    public boolean isSet(final String pref) {
+        return prefs.contains(pref);
+    }
+
+    // booleans
+    public boolean getBooleanDefaultFalse(final String pref) {
+        return prefs.getBoolean(pref, false);
+    }
+
+    public boolean getBoolean(final String pref, boolean def) {
+        return prefs.getBoolean(pref, def);
+    }
+
+    public boolean setBoolean(final String pref, final boolean lng) {
+        prefs.edit().putBoolean(pref, lng).apply();
+        return true;
+    }
+
+    public void toggleBoolean(final String pref) {
+        prefs.edit().putBoolean(pref, !prefs.getBoolean(pref, false)).apply();
+    }
+
+    public void parsePrefs(final String tag, final String msg) {
+        if (msg.startsWith(CHANGE_PREFS_SPECIAL_CASE)) {
+            final StringTokenizer st = new StringTokenizer(msg, CHANGE_PREFS_SPECIAL_CASE_DELIMITER);
+            if (st.countTokens() == 3) {
+                st.nextToken(); // skip prefix
+                final String name = st.nextToken();
+                final String value = st.nextToken();
+                android.util.Log.d(tag, "Setting: " + name + " -> " + value);
+                if ((name != null) && (name.length() > 0)) {
+                    switch (value) {
+                        case "true":
+                            setBoolean(name, true);
+                            break;
+                        case "false":
+                            setBoolean(name, false);
+                            break;
+                        default:
+                            setString(name, value);
+                            break;
+                    }
+                }
+
+            } else {
+                android.util.Log.d(tag, "Invalid number of prefs tokens: " + st.countTokens());
+            }
+        }
+    }
+
+    @SuppressLint("ApplySharedPref")
+    public void commit() {
+        prefs.edit().commit();
+    }
+
+}

--- a/sightparser/src/main/java/sugar/free/sightparser/error/NotAuthorizedError.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/error/NotAuthorizedError.java
@@ -1,4 +1,12 @@
 package sugar.free.sightparser.error;
 
 public class NotAuthorizedError extends SightError {
+
+    public NotAuthorizedError() {
+        super();
+    }
+
+    public NotAuthorizedError(String message) {
+        super(message);
+    }
 }

--- a/sightparser/src/main/java/sugar/free/sightparser/error/SightError.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/error/SightError.java
@@ -2,4 +2,11 @@ package sugar.free.sightparser.error;
 
 public abstract class SightError extends Exception {
 
+    public SightError() {
+        super();
+    }
+
+    public SightError(String message) {
+        super(message);
+    }
 }

--- a/sightparser/src/main/java/sugar/free/sightparser/handling/FirewallConstraint.java
+++ b/sightparser/src/main/java/sugar/free/sightparser/handling/FirewallConstraint.java
@@ -1,0 +1,77 @@
+package sugar.free.sightparser.handling;
+
+import android.content.Context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import sugar.free.sightparser.Pref;
+import sugar.free.sightparser.applayer.messages.AppLayerMessage;
+import sugar.free.sightparser.applayer.messages.remote_control.ChangeTBRMessage;
+import sugar.free.sightparser.applayer.messages.remote_control.ExtendedBolusMessage;
+import sugar.free.sightparser.applayer.messages.remote_control.StandardBolusMessage;
+
+
+/**
+ * Created by jamorham on 01/02/2018.
+ *
+ * Allow or deny Applayer messages based on a mapped preference boolean
+ *
+ * Undefined items are allowed by default
+ *
+ */
+
+
+public class FirewallConstraint {
+
+    private static final String FIREWALL_STORAGE = "SERVICE_FIREWALL";
+    private static final String TAG = "INSIGHTFIREWALL";
+    private static final Map<Class, String> lookup;
+    private static final boolean d = false;
+
+    static {
+        lookup = new HashMap<>();
+        // these message types will be restricted by the named preference item
+        lookup.put(StandardBolusMessage.class, "firewall_allow_standard_bolus");
+        lookup.put(ExtendedBolusMessage.class, "firewall_allow_extended_bolus");
+        lookup.put(ChangeTBRMessage.class, "firewall_allow_temporary_basal");
+    }
+
+    private final Pref pref;
+
+    public FirewallConstraint(Context context) {
+        pref = Pref.get(context, FIREWALL_STORAGE);
+        initializeDefaults();
+    }
+
+    private void initializeDefaults() {
+        // set unset class types to allow by default
+        for (Map.Entry<Class, String> item : lookup.entrySet()) {
+            if (!pref.isSet(item.getValue())) {
+                pref.setBoolean(item.getValue(), true);
+            }
+        }
+    }
+
+    void parsePreference(String packageName) {
+        android.util.Log.d(TAG, "Updating preferences");
+        pref.parsePrefs(TAG, packageName);
+    }
+
+    boolean isAllowed(AppLayerMessage msg) {
+        if (msg == null) return true; // not sure if this should be false as its invalid
+        final String prefString = lookup.get(msg.getClass());
+        if (prefString == null) {
+            if (d) android.util.Log.e(TAG, "FIREWALL default Allow: " + msg);
+            return true; // default allow
+        }
+        final boolean allow = pref.getBooleanDefaultFalse(prefString);
+        if (!allow) {
+            android.util.Log.e(TAG, "FIREWALL Blocked: " + msg);
+        } else {
+            android.util.Log.e(TAG, "FIREWALL Allow: " + msg);
+        }
+        return allow;
+    }
+
+}


### PR DESCRIPTION
This provides a menu to enable/disable pump features. It works by checked permission for the message types and blocking them if they don't have permission approved. Permissions default to enabled and message types not yet added to the definitions are allowed through by default.

The idea is that if you for example want to use AAPS in a way that it only adjusts temporary basals but you don't want to have to worry that the app could open itself and do something crazy if the phone were bouncing around in your bag then this can disable parts of the functionality you don't want to use. The objective is to improve safety and user control + choice + confidence in the app.

Adds a new `FirewallConstraint` class and associated data storage and configuration activity. The layout and content of the activity is controlled purely via its xml definition and no logic is needed in the activity class itself. 

Only 3 different message types are supported at the moment, but adding more is very easy.

I've also extended the exceptions so they can support text messages to describe reasons for failure. A toast-pop-up is created by the service when a permission blocks something so the user who forgets they enabled the firewall doesn't think it is just broken.

The options are stored in a preference store which has to be relayed via the bound interface due to the service being in another process. To avoid further extending the aidl interface and introducing incompatibilities I used special case pattern to push this through the existing package authorizing feature with a marker to allow firewall settings on the remote side.

Code reformatting caused some items to be rearranged in the service class but there are no operational changes other than those needed for this feature.

The extracted strings are duplicated in the german strings file. If merged you may then want to translate these.

Hope you like it.